### PR TITLE
Update release notes generator config to use eslint preset

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js: node
+if: tag IS blank # skip building on tags
 addons:
   chrome: stable
 script:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # d2l-custom-teacher-course-creation
 
 [![Dependabot badge](https://flat.badgen.net/dependabot/Brightspace/custom-teacher-course-creation?icon=dependabot)](https://app.dependabot.com/)
-[![Build status](https://travis-ci.com/@brightspace-ui/custom-teacher-course-creation.svg?branch=master)](https://travis-ci.com/@brightspace-ui/custom-teacher-course-creation)
+[![Build status](https://travis-ci.com/@brightspace/custom-teacher-course-creation.svg?branch=master)](https://travis-ci.com/@brightspace-ui/custom-teacher-course-creation)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # d2l-custom-teacher-course-creation
 
-[![Dependabot badge](https://flat.badgen.net/dependabot/BrightspaceUI/custom-teacher-course-creation?icon=dependabot)](https://app.dependabot.com/)
+[![Dependabot badge](https://flat.badgen.net/dependabot/Brightspace/custom-teacher-course-creation?icon=dependabot)](https://app.dependabot.com/)
 [![Build status](https://travis-ci.com/@brightspace-ui/custom-teacher-course-creation.svg?branch=master)](https://travis-ci.com/@brightspace-ui/custom-teacher-course-creation)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # d2l-custom-teacher-course-creation
 
 [![Dependabot badge](https://flat.badgen.net/dependabot/Brightspace/custom-teacher-course-creation?icon=dependabot)](https://app.dependabot.com/)
-[![Build status](https://travis-ci.com/@brightspace/custom-teacher-course-creation.svg?branch=master)](https://travis-ci.com/@brightspace-ui/custom-teacher-course-creation)
+[![Build status](https://travis-ci.com/brightspace/custom-teacher-course-creation.svg?branch=master)](https://travis-ci.com/@brightspace-ui/custom-teacher-course-creation)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
 ## Installation

--- a/package.json
+++ b/package.json
@@ -67,7 +67,12 @@
         }
       ],
       "@semantic-release/github",
-      "@semantic-release/release-notes-generator",
+      [
+        "@semantic-release/release-notes-generator",
+        {
+          "preset": "eslint"
+        }
+      ],
       [
         "@semantic-release/git",
         {

--- a/package.json
+++ b/package.json
@@ -72,15 +72,6 @@
         {
           "preset": "eslint"
         }
-      ],
-      [
-        "@semantic-release/git",
-        {
-          "assets": [
-            "package.json"
-          ],
-          "message": "Chore: ${nextRelease.version} [skip ci]"
-        }
       ]
     ]
   }


### PR DESCRIPTION
Also taking this opportunity to fix the dependabot badge

I also did a dry-run with the semantic-release to ensure that the fix would work, and it does generate the release-notes properly.

![semantic-release-dry-run](https://user-images.githubusercontent.com/64805612/87580521-a518f080-c6a5-11ea-8ec0-6f5d73161742.png)
